### PR TITLE
[HIVE-15005] Path does not add slash in hive.cluster.delegation.token…

### DIFF
--- a/shims/common/src/main/java/org/apache/hadoop/hive/thrift/ZooKeeperTokenStore.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/thrift/ZooKeeperTokenStore.java
@@ -459,9 +459,13 @@ public class ZooKeeperTokenStore implements DelegationTokenStore {
     if (StringUtils.isNotBlank(aclStr)) {
       this.newNodeAcl = parseACLs(aclStr);
     }
-    rootNode =
+
+    String delegationZnode =
         conf.get(HiveDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_ZNODE,
-            HiveDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_ZNODE_DEFAULT) + serverMode;
+            HiveDelegationTokenManager.DELEGATION_TOKEN_STORE_ZK_ZNODE_DEFAULT);
+    // Remove trailing '/'
+    delegationZnode = delegationZnode.replaceAll("/$", "");
+    rootNode = delegationZnode + "/" + serverMode;
 
     try {
       // Install the JAAS Configuration for the runtime


### PR DESCRIPTION
….store.zookeeper.znode config

If set 'hive.cluster.delegation.token.store.zookeeper.znode=/hive/cluster/delegation',
the new node path will be '/hive/cluster/delegationMETASTORE/tokens'.
It should be /hive/cluster/delegation/METASTORE/tokens.

It seems if I set hive.cluster.delegation.token.store.zookeeper.znode=/hive/cluster/delegation/,
the final path would be /hive/cluster/delegation/METASTORE.
So I just think it would be better to add a slash.
